### PR TITLE
设置 MiraiBot 为不可复制类; 修改 EventBase 使得可以通过事件获得 MiraiBot;

### DIFF
--- a/include/events/bot_join_group.hpp
+++ b/include/events/bot_join_group.hpp
@@ -20,16 +20,12 @@ namespace Cyan
 			return MiraiEvent::BotJoinGroupEvent;
 		}
 
-		virtual void SetMiraiBot(MiraiBot* bot) override
-		{
-			this->bot_ = bot;
-		}
-
 		virtual bool Set(const json& j) override
 		{
 			this->Group.Set(j["group"]);
 			return true;
 		}
+		
 		virtual json ToJson() const override
 		{
 			json j = json::object();
@@ -37,9 +33,6 @@ namespace Cyan
 			j["group"] = this->Group.ToJson();
 			return j;
 		}
-
-	private:
-		MiraiBot* bot_;
 	};
 
 }

--- a/include/events/bot_leave_active.hpp
+++ b/include/events/bot_leave_active.hpp
@@ -20,11 +20,6 @@ namespace Cyan
 			return MiraiEvent::BotLeaveEventActive;
 		}
 
-		virtual void SetMiraiBot(MiraiBot* bot) override
-		{
-			this->bot_ = bot;
-		}
-
 		virtual bool Set(const json& j) override
 		{
 			this->Group.Set(j["group"]);
@@ -37,9 +32,6 @@ namespace Cyan
 			j["group"] = this->Group.ToJson();
 			return j;
 		}
-
-	private:
-		MiraiBot* bot_;
 	};
 
 }

--- a/include/events/bot_leave_kick.hpp
+++ b/include/events/bot_leave_kick.hpp
@@ -20,11 +20,6 @@ namespace Cyan
 			return MiraiEvent::BotLeaveEventKick;
 		}
 
-		virtual void SetMiraiBot(MiraiBot* bot) override
-		{
-			this->bot_ = bot;
-		}
-
 		virtual bool Set(const json& j) override
 		{
 			this->Group.Set(j["group"]);
@@ -38,8 +33,6 @@ namespace Cyan
 			return j;
 		}
 
-	private:
-		MiraiBot* bot_;
 	};
 
 }

--- a/include/events/bot_mute_event.hpp
+++ b/include/events/bot_mute_event.hpp
@@ -21,11 +21,6 @@ namespace Cyan
 			return MiraiEvent::BotMuteEvent;
 		}
 
-		virtual void SetMiraiBot(MiraiBot* bot) override
-		{
-			this->bot_ = bot;
-		}
-
 		virtual bool Set(const json& j) override
 		{
 			this->DurationSeconds = j["durationSeconds"].get<int>();
@@ -41,8 +36,6 @@ namespace Cyan
 			return j;
 		}
 
-	private:
-		MiraiBot* bot_;
 	};
 
 }

--- a/include/events/bot_offline_active.hpp
+++ b/include/events/bot_offline_active.hpp
@@ -20,11 +20,6 @@ namespace Cyan
 			return MiraiEvent::BotOfflineEventActive;
 		}
 
-		virtual void SetMiraiBot(MiraiBot* bot) override
-		{
-			this->bot_ = bot;
-		}
-
 		virtual bool Set(const json& j) override
 		{
 			this->QQ = (QQ_t)(j["qq"].get<int64_t>());
@@ -37,9 +32,6 @@ namespace Cyan
 			j["qq"] = (int64_t)this->QQ;
 			return j;
 		}
-
-	private:
-		MiraiBot* bot_;
 	};
 
 }

--- a/include/events/bot_offline_dropped.hpp
+++ b/include/events/bot_offline_dropped.hpp
@@ -20,11 +20,6 @@ namespace Cyan
 			return MiraiEvent::BotOfflineEventDropped;
 		}
 
-		virtual void SetMiraiBot(MiraiBot* bot) override
-		{
-			this->bot_ = bot;
-		}
-
 		virtual bool Set(const json& j) override
 		{
 			this->QQ = (QQ_t)(j["qq"].get<int64_t>());
@@ -37,9 +32,6 @@ namespace Cyan
 			j["qq"] = (int64_t)this->QQ;
 			return j;
 		}
-
-	private:
-		MiraiBot* bot_;
 	};
 
 }

--- a/include/events/bot_offline_force.hpp
+++ b/include/events/bot_offline_force.hpp
@@ -20,11 +20,6 @@ namespace Cyan
 			return MiraiEvent::BotOfflineEventForce;
 		}
 
-		virtual void SetMiraiBot(MiraiBot* bot) override
-		{
-			this->bot_ = bot;
-		}
-
 		virtual bool Set(const json& j) override
 		{
 			this->QQ = (QQ_t)(j["qq"].get<int64_t>());
@@ -37,9 +32,6 @@ namespace Cyan
 			j["qq"] = (int64_t)this->QQ;
 			return j;
 		}
-
-	private:
-		MiraiBot* bot_;
 	};
 
 }

--- a/include/events/bot_online_event.hpp
+++ b/include/events/bot_online_event.hpp
@@ -20,11 +20,6 @@ namespace Cyan
 			return MiraiEvent::BotOnlineEvent;
 		}
 
-		virtual void SetMiraiBot(MiraiBot* bot) override
-		{
-			this->bot_ = bot;
-		}
-
 		virtual bool Set(const json& j) override
 		{
 			this->QQ = (QQ_t)(j["qq"].get<int64_t>());
@@ -38,8 +33,6 @@ namespace Cyan
 			return j;
 		}
 
-	private:
-		MiraiBot* bot_;
 	};
 
 }

--- a/include/events/bot_relogin_event.hpp
+++ b/include/events/bot_relogin_event.hpp
@@ -20,11 +20,6 @@ namespace Cyan
 			return MiraiEvent::BotReloginEvent;
 		}
 
-		virtual void SetMiraiBot(MiraiBot* bot) override
-		{
-			this->bot_ = bot;
-		}
-
 		virtual bool Set(const json& j) override
 		{
 			this->QQ = (QQ_t)(j["qq"].get<int64_t>());
@@ -37,9 +32,6 @@ namespace Cyan
 			j["qq"] = (int64_t)this->QQ;
 			return j;
 		}
-
-	private:
-		MiraiBot* bot_;
 	};
 
 }

--- a/include/events/bot_unmute_event.hpp
+++ b/include/events/bot_unmute_event.hpp
@@ -22,11 +22,6 @@ namespace Cyan
 			return MiraiEvent::BotUnmuteEvent;
 		}
 
-		virtual void SetMiraiBot(MiraiBot* bot) override
-		{
-			this->bot_ = bot;
-		}
-
 		virtual bool Set(const json& j) override
 		{
 			this->Operator.Set(j["operator"]);
@@ -40,8 +35,6 @@ namespace Cyan
 			return j;
 		}
 
-	private:
-		MiraiBot* bot_;
 	};
 
 }

--- a/include/events/event_interface.hpp
+++ b/include/events/event_interface.hpp
@@ -9,13 +9,23 @@ namespace Cyan
 	class EventBase : public Serializable
 	{
 	public:
-		EventBase() {}
+		EventBase() : bot_(nullptr) {}
+
 		static MiraiEvent GetMiraiEvent()
 		{
 			return MiraiEvent::Default;
 		}
-		virtual void SetMiraiBot(MiraiBot*) = 0;
+		virtual void SetMiraiBot(MiraiBot* bot)
+		{
+			this->bot_ = bot;
+		}
+		virtual MiraiBot& GetMiraiBot()
+		{
+			return *bot_;
+		}
 		virtual ~EventBase() {}
+	protected:
+		MiraiBot* bot_;
 	};
 
 

--- a/include/events/event_interface.hpp
+++ b/include/events/event_interface.hpp
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 #ifndef mirai_cpp_events_event_interface_hpp_H_
 #define mirai_cpp_events_event_interface_hpp_H_
 #include "mirai_event.hpp"
@@ -11,19 +11,40 @@ namespace Cyan
 	public:
 		EventBase() : bot_(nullptr) {}
 
+		EventBase(const EventBase& eb)
+		{
+			this->bot_ = eb.bot_;
+		}
+
+		EventBase(EventBase&& eb) noexcept: bot_(nullptr)
+		{
+			std::swap(this->bot_, eb.bot_);
+		}
+
+		EventBase& operator=(const EventBase& eb)
+		{
+			EventBase tmp(eb);
+			std::swap(this->bot_, tmp.bot_);
+			return *this;
+		}
+		
+		virtual ~EventBase() = default;
+		
 		static MiraiEvent GetMiraiEvent()
 		{
 			return MiraiEvent::Default;
 		}
+		
 		virtual void SetMiraiBot(MiraiBot* bot)
 		{
 			this->bot_ = bot;
 		}
+		
 		virtual MiraiBot& GetMiraiBot()
 		{
 			return *bot_;
 		}
-		virtual ~EventBase() {}
+		
 	protected:
 		MiraiBot* bot_;
 	};

--- a/include/events/friend_message.hpp
+++ b/include/events/friend_message.hpp
@@ -34,11 +34,6 @@ namespace Cyan
 			return this->MessageChain.GetTimestamp();
 		}
 
-		virtual void SetMiraiBot(MiraiBot* bot) override
-		{
-			this->bot_ = bot;
-		}
-
 		MessageId Reply(const Cyan::MessageChain& mc) const;
 		MessageId QuoteReply(const Cyan::MessageChain& mc) const;
 
@@ -56,9 +51,6 @@ namespace Cyan
 			j["sender"] = this->Sender.ToJson();
 			return j;
 		}
-
-	private:
-		MiraiBot* bot_;
 	};
 
 }

--- a/include/events/friend_recall_event.hpp
+++ b/include/events/friend_recall_event.hpp
@@ -25,12 +25,6 @@ namespace Cyan
 			return MiraiEvent::FriendRecallEvent;
 		}
 
-
-		virtual void SetMiraiBot(MiraiBot* bot) override
-		{
-			this->bot_ = bot;
-		}
-
 		virtual bool Set(const json& j) override
 		{
 			this->Time = j["time"].get<int64_t>();
@@ -49,9 +43,6 @@ namespace Cyan
 			j["operator"] = (int64_t)this->Operator;
 			return j;
 		}
-
-	private:
-		MiraiBot* bot_;
 	};
 
 }

--- a/include/events/group_message.hpp
+++ b/include/events/group_message.hpp
@@ -34,11 +34,6 @@ namespace Cyan
 			return (this->MessageChain).GetTimestamp();
 		}
 
-		virtual void SetMiraiBot(MiraiBot* bot) override
-		{
-			this->bot_ = bot;
-		}
-
 		MessageId Reply(const Cyan::MessageChain& mc) const;
 		MessageId QuoteReply(const Cyan::MessageChain& mc) const;
 		bool Recall() const;
@@ -57,8 +52,6 @@ namespace Cyan
 			j["sender"] = this->Sender.ToJson();
 			return j;
 		}
-	private:
-		MiraiBot* bot_;
 	};
 }
 

--- a/include/events/group_name_change.hpp
+++ b/include/events/group_name_change.hpp
@@ -24,11 +24,6 @@ namespace Cyan
 			return MiraiEvent::GroupNameChangeEvent;
 		}
 
-		virtual void SetMiraiBot(MiraiBot* bot) override
-		{
-			this->bot_ = bot;
-		}
-
 		bool OperatorIsBot() const
 		{
 			return operator_is_null_;
@@ -58,7 +53,6 @@ namespace Cyan
 		}
 
 	private:
-		MiraiBot* bot_;
 		bool operator_is_null_ = true;
 	};
 

--- a/include/events/group_recall_event.hpp
+++ b/include/events/group_recall_event.hpp
@@ -25,11 +25,6 @@ namespace Cyan
 			return MiraiEvent::GroupRecallEvent;
 		}
 
-		virtual void SetMiraiBot(MiraiBot* bot) override
-		{
-			this->bot_ = bot;
-		}
-
 		virtual bool Set(const json& j) override
 		{
 			this->Time = j["time"].get<int64_t>();
@@ -50,9 +45,6 @@ namespace Cyan
 			j["operator"] = this->Operator.ToJson();
 			return j;
 		}
-
-	private:
-		MiraiBot* bot_;
 	};
 
 }

--- a/include/events/join_request_event.hpp
+++ b/include/events/join_request_event.hpp
@@ -28,11 +28,6 @@ namespace Cyan
 			return MiraiEvent::MemberJoinRequestEvent;
 		}
 
-		virtual void SetMiraiBot(MiraiBot* bot) override
-		{
-			this->bot_ = bot;
-		}
-
 		bool Accept()
 		{
 			return Response(0, "");
@@ -82,7 +77,6 @@ namespace Cyan
 		}
 
 	private:
-		MiraiBot* bot_;
 		bool Response(int operate, const string& message);
 	};
 

--- a/include/events/member_join_event.hpp
+++ b/include/events/member_join_event.hpp
@@ -22,12 +22,6 @@ namespace Cyan
 			return MiraiEvent::MemberJoinEvent;
 		}
 
-
-		virtual void SetMiraiBot(MiraiBot* bot) override
-		{
-			this->bot_ = bot;
-		}
-
 		virtual bool Set(const json& j) override
 		{
 			this->NewMember.Set(j["member"]);
@@ -41,8 +35,6 @@ namespace Cyan
 			return j;
 		}
 
-	private:
-		MiraiBot* bot_;
 	};
 
 }

--- a/include/events/member_leave_kick.hpp
+++ b/include/events/member_leave_kick.hpp
@@ -22,11 +22,6 @@ namespace Cyan
 			return MiraiEvent::MemberLeaveEventKick;
 		}
 
-		virtual void SetMiraiBot(MiraiBot* bot) override
-		{
-			this->bot_ = bot;
-		}
-
 		virtual bool Set(const json& j) override
 		{
 			this->Member.Set(j["member"]);
@@ -42,8 +37,6 @@ namespace Cyan
 			return j;
 		}
 
-	private:
-		MiraiBot* bot_;
 	};
 
 }

--- a/include/events/member_leave_quit.hpp
+++ b/include/events/member_leave_quit.hpp
@@ -21,11 +21,6 @@ namespace Cyan
 			return MiraiEvent::MemberLeaveEventQuit;
 		}
 
-		virtual void SetMiraiBot(MiraiBot* bot) override
-		{
-			this->bot_ = bot;
-		}
-
 		virtual bool Set(const json& j) override
 		{
 			this->Member.Set(j["member"]);
@@ -38,9 +33,6 @@ namespace Cyan
 			j["member"] = this->Member.ToJson();
 			return j;
 		}
-
-	private:
-		MiraiBot* bot_;
 	};
 
 }

--- a/include/events/member_mute_event.hpp
+++ b/include/events/member_mute_event.hpp
@@ -23,11 +23,6 @@ namespace Cyan
 			return MiraiEvent::MemberMuteEvent;
 		}
 
-		virtual void SetMiraiBot(MiraiBot* bot) override
-		{
-			this->bot_ = bot;
-		}
-
 		bool OperatorIsBot() const
 		{
 			return operator_is_null_;
@@ -55,7 +50,6 @@ namespace Cyan
 		}
 
 	private:
-		MiraiBot* bot_;
 		bool operator_is_null_ = true;
 	};
 

--- a/include/events/member_unmute_event.hpp
+++ b/include/events/member_unmute_event.hpp
@@ -22,11 +22,6 @@ namespace Cyan
 			return MiraiEvent::MemberUnmuteEvent;
 		}
 
-		virtual void SetMiraiBot(MiraiBot* bot) override
-		{
-			this->bot_ = bot;
-		}
-
 		bool OperatorIsBot() const
 		{
 			return operator_is_null_;
@@ -52,7 +47,6 @@ namespace Cyan
 		}
 
 	private:
-		MiraiBot* bot_;
 		bool operator_is_null_ = true;
 	};
 

--- a/include/events/message_event.hpp
+++ b/include/events/message_event.hpp
@@ -68,11 +68,6 @@ namespace Cyan
 			return (this->MessageChain).GetTimestamp();
 		}
 
-		virtual void SetMiraiBot(MiraiBot* bot) override
-		{
-			this->bot_ = bot;
-		}
-
 		MessageId Reply(const Cyan::MessageChain& mc) const;
 		MessageId QuoteReply(const Cyan::MessageChain& mc) const;
 
@@ -106,7 +101,6 @@ namespace Cyan
 			return json_;
 		}
 	private:
-		MiraiBot* bot_;
 		json json_;
 		MessageType messageType_;
 		FriendMessage friendMessage_;

--- a/include/events/new_friend_event.hpp
+++ b/include/events/new_friend_event.hpp
@@ -27,11 +27,6 @@ namespace Cyan
 			return MiraiEvent::FriendRecallEvent;
 		}
 
-		virtual void SetMiraiBot(MiraiBot* bot) override
-		{
-			this->bot_ = bot;
-		}
-
 		bool Accept()
 		{
 			return Response(0, "");
@@ -69,7 +64,6 @@ namespace Cyan
 		}
 
 	private:
-		MiraiBot* bot_;
 		bool Response(int operate, const string& message);
 	};
 

--- a/include/events/temp_message.hpp
+++ b/include/events/temp_message.hpp
@@ -24,11 +24,6 @@ namespace Cyan
 			return MiraiEvent::TempMessage;
 		}
 
-		virtual void SetMiraiBot(MiraiBot* bot) override
-		{
-			this->bot_ = bot;
-		}
-
 		MessageId GetMessageId() const
 		{
 			return (this->MessageChain).GetMessageId();
@@ -55,8 +50,6 @@ namespace Cyan
 			j["sender"] = this->Sender.ToJson();
 			return j;
 		}
-	private:
-		MiraiBot* bot_;
 	};
 
 

--- a/include/mirai_bot.hpp
+++ b/include/mirai_bot.hpp
@@ -44,6 +44,8 @@ namespace Cyan
 		 * \param port port
 		 */
 		MiraiBot(const string& host, int port);
+		MiraiBot(const MiraiBot&) = delete;
+		MiraiBot& operator=(const MiraiBot&) = delete;
 		~MiraiBot();
 
 		/**


### PR DESCRIPTION
1. 设置 MiraiBot 为不可复制类; (因为成员变量 httplib::Client client_ 不可复制)
2. 修改 EventBase 使得可以通过事件获得 MiraiBot;