### PR TITLE
mirai_bot.hpp不再引用所有定义和事件；

### DIFF
--- a/examples/BotEvents.cpp
+++ b/examples/BotEvents.cpp
@@ -1,7 +1,16 @@
 ﻿#include <iostream>
 // 使用静态库必须要在引入 mirai.h 前定义这个宏
 #define MIRAICPP_STATICLIB
-#include <mirai.h>
+#include <mirai_bot.hpp>
+#include <events/bot_join_group.hpp>
+#include <events/bot_mute_event.hpp>
+#include <events/bot_unmute_event.hpp>
+#include <events/bot_leave_kick.hpp>
+#include <events/bot_online_event.hpp>
+#include <events/bot_offline_active.hpp>
+#include <events/bot_offline_force.hpp>
+#include <events/bot_offline_dropped.hpp>
+#include <events/bot_relogin_event.hpp>
 
 int main()
 {

--- a/examples/RichMessage.cpp
+++ b/examples/RichMessage.cpp
@@ -28,6 +28,23 @@ int main()
 	GroupImage gImg = bot.UploadGroupImage("D:\\test.png");
 	TempImage tImg = bot.UploadTempImage("D:\\test.png");
 
+	bot.On<Message>([&](Message m)
+		{
+			try
+			{
+				if(m.MessageChain.GetPlainTextFirst() == "点歌")
+				{
+					m.Reply(MessageChain().App(R"( {"app":"com.tencent.structmsg","config":{"autosize":true,"ctime":1592909927,"forward":true,"token":"8e01d9ea9297158cef76512886cfe8bc","type":"normal"},"desc":"新闻","extra":{"app_type":1,"appid":100497308,"msg_seq":6841496030403626000},"meta":{"news":{"action":"","android_pkg_name":"","app_type":1,"appid":100497308,"desc":"周杰伦","jumpUrl":"https://i.y.qq.com/v8/playsong.html?platform=11&appshare=android_qq&appversion=9160007&songmid=004Z8Ihr0JIu5s&type=0&appsongtype=1&_wv=1&source=qq&ADTAG=qfshare","preview":"https://y.gtimg.cn/music/photo_new/T002R300x300M000003DFRzD192KKD.jpg","source_icon":"","source_url":"","tag":"QQ音乐","title":"七里香"}},"prompt":"[分享]七里香","ver":"0.0.0.1","view":"news"} )"));
+				}
+				cout << m.ToString() << endl;
+			}
+			catch (const exception& ex)
+			{
+				cout << ex.what() << endl;
+			}
+		});
+
+	
 	bot.On<FriendMessage>(
 		[&](FriendMessage fm)
 		{

--- a/include/events/bot_join_group.hpp
+++ b/include/events/bot_join_group.hpp
@@ -3,13 +3,15 @@
 #define mirai_cpp_events_bot_join_group_hpp_H_
 
 #include <nlohmann/json.hpp>
-#include "defs/qq_types.hpp"
-#include "defs/group.hpp"
 #include "event_interface.hpp"
+#include "defs/group.hpp"
 
 namespace Cyan
 {
-	// bot 加入新群事件
+
+	/**
+	 * \brief bot 加入新群事件
+	 */
 	class BotJoinGroupEvent : public EventBase
 	{
 	public:

--- a/include/events/bot_leave_active.hpp
+++ b/include/events/bot_leave_active.hpp
@@ -3,13 +3,15 @@
 #define mirai_cpp_events_bot_leave_active_hpp_H_
 
 #include <nlohmann/json.hpp>
-#include "defs/qq_types.hpp"
 #include "defs/group.hpp"
 #include "event_interface.hpp"
 
 namespace Cyan
 {
-	// bot 主动退群
+
+	/**
+	 * \brief bot 主动退群
+	 */
 	class BotLeaveEventActive : public EventBase
 	{
 	public:

--- a/include/events/bot_leave_kick.hpp
+++ b/include/events/bot_leave_kick.hpp
@@ -3,13 +3,15 @@
 #define mirai_cpp_events_bot_leave_kick_hpp_H_
 
 #include <nlohmann/json.hpp>
-#include "defs/qq_types.hpp"
 #include "defs/group.hpp"
 #include "event_interface.hpp"
 
 namespace Cyan
 {
-	// bot 被踢出群
+
+	/**
+	 * \brief bot 被踢出群
+	 */
 	class BotLeaveEventKick : public EventBase
 	{
 	public:

--- a/include/events/bot_mute_event.hpp
+++ b/include/events/bot_mute_event.hpp
@@ -3,13 +3,15 @@
 #define mirai_cpp_events_bot_mute_event_hpp_H_
 
 #include <nlohmann/json.hpp>
-#include "defs/qq_types.hpp"
 #include "defs/group_member.hpp"
 #include "event_interface.hpp"
 
 namespace Cyan
 {
-	// bot 被禁言事件
+
+	/**
+	 * \brief bot 被禁言事件
+	 */
 	class BotMuteEvent : public EventBase
 	{
 	public:

--- a/include/events/bot_offline_active.hpp
+++ b/include/events/bot_offline_active.hpp
@@ -4,12 +4,13 @@
 
 #include <nlohmann/json.hpp>
 #include "defs/qq_types.hpp"
-#include "defs/serializable.hpp"
 #include "event_interface.hpp"
 
 namespace Cyan
 {
-	// bot 主动离线事件
+	/**
+	 * \brief bot 主动离线事件
+	 */
 	class BotOfflineEventActive : public EventBase
 	{
 	public:

--- a/include/events/bot_offline_dropped.hpp
+++ b/include/events/bot_offline_dropped.hpp
@@ -4,12 +4,14 @@
 
 #include <nlohmann/json.hpp>
 #include "defs/qq_types.hpp"
-#include "defs/serializable.hpp"
 #include "event_interface.hpp"
 
 namespace Cyan
 {
-	// bot 因网络原因掉线
+
+	/**
+	 * \brief bot 因网络原因掉线
+	 */
 	class BotOfflineEventDropped : public EventBase
 	{
 	public:

--- a/include/events/bot_offline_force.hpp
+++ b/include/events/bot_offline_force.hpp
@@ -4,12 +4,13 @@
 
 #include <nlohmann/json.hpp>
 #include "defs/qq_types.hpp"
-#include "defs/serializable.hpp"
 #include "event_interface.hpp"
 
 namespace Cyan
 {
-	// bot 被挤下线事件
+	/**
+	 * \brief bot 被挤下线事件
+	 */
 	class BotOfflineEventForce : public EventBase
 	{
 	public:

--- a/include/events/bot_online_event.hpp
+++ b/include/events/bot_online_event.hpp
@@ -4,12 +4,13 @@
 
 #include <nlohmann/json.hpp>
 #include "defs/qq_types.hpp"
-#include "defs/serializable.hpp"
 #include "event_interface.hpp"
 
 namespace Cyan
 {
-	// bot 登录成功事件
+	/**
+	 * \brief bot 登录成功事件
+	 */
 	class BotOnlineEvent : public EventBase
 	{
 	public:

--- a/include/events/bot_relogin_event.hpp
+++ b/include/events/bot_relogin_event.hpp
@@ -4,12 +4,13 @@
 
 #include <nlohmann/json.hpp>
 #include "defs/qq_types.hpp"
-#include "defs/serializable.hpp"
 #include "event_interface.hpp"
 
 namespace Cyan
 {
-	// bot 主动重新登录事件
+	/**
+	 * \brief bot 主动重新登录事件
+	 */
 	class BotReloginEvent : public EventBase
 	{
 	public:

--- a/include/events/bot_unmute_event.hpp
+++ b/include/events/bot_unmute_event.hpp
@@ -3,15 +3,14 @@
 #define mirai_cpp_events_bot_unmute_event_hpp_H_
 
 #include <nlohmann/json.hpp>
-#include "defs/qq_types.hpp"
-#include "defs/serializable.hpp"
-#include "defs/message_chain.hpp"
 #include "defs/group_member.hpp"
 #include "event_interface.hpp"
 
 namespace Cyan
 {
-	// bot 被解除禁言事件
+	/**
+	 * \brief bot 被解除禁言事件
+	 */
 	class BotUnmuteEvent : public EventBase
 	{
 	public:

--- a/include/events/event_processer.hpp
+++ b/include/events/event_processer.hpp
@@ -4,6 +4,7 @@
 
 #include <functional>
 #include <memory>
+#include "event_interface.hpp"
 
 namespace Cyan
 {

--- a/include/events/friend_message.hpp
+++ b/include/events/friend_message.hpp
@@ -4,7 +4,6 @@
 
 #include <nlohmann/json.hpp>
 #include "defs/qq_types.hpp"
-#include "defs/serializable.hpp"
 #include "defs/message_chain.hpp"
 #include "defs/friend.hpp"
 #include "exported.h"
@@ -12,7 +11,9 @@
 
 namespace Cyan
 {
-	// 好友发来的消息
+	/**
+	 * \brief 好友发来的消息
+	 */
 	class EXPORTED FriendMessage : public EventBase
 	{
 	public:

--- a/include/events/friend_recall_event.hpp
+++ b/include/events/friend_recall_event.hpp
@@ -4,13 +4,13 @@
 
 #include <nlohmann/json.hpp>
 #include "defs/qq_types.hpp"
-#include "defs/serializable.hpp"
-#include "defs/group_member.hpp"
 #include "event_interface.hpp"
 
 namespace Cyan
 {
-	// 好友消息撤回事件
+	/**
+	 * \brief 好友消息撤回事件
+	 */
 	class FriendRecallEvent : public EventBase
 	{
 	public:

--- a/include/events/group_message.hpp
+++ b/include/events/group_message.hpp
@@ -4,7 +4,6 @@
 
 #include <nlohmann/json.hpp>
 #include "defs/qq_types.hpp"
-#include "defs/serializable.hpp"
 #include "defs/message_chain.hpp"
 #include "defs/group_member.hpp"
 #include "event_interface.hpp"
@@ -12,7 +11,9 @@
 
 namespace Cyan
 {
-	// 群组发来的消息
+	/**
+	 * \brief 群组发来的消息
+	 */
 	class EXPORTED GroupMessage : public EventBase
 	{
 	public:

--- a/include/events/group_mute_all_event.hpp
+++ b/include/events/group_mute_all_event.hpp
@@ -9,7 +9,9 @@
 
 namespace Cyan
 {
-	// 群全体禁言事件
+	/**
+	 * \brief 群全体禁言事件
+	 */
 	class GroupMuteAllEvent : public EventBase
 	{
 	public:

--- a/include/events/group_name_change.hpp
+++ b/include/events/group_name_change.hpp
@@ -9,7 +9,9 @@
 
 namespace Cyan
 {
-	// 群名称被改变
+	/**
+	 * \brief 群名称被改变
+	 */
 	class GroupNameChangeEvent : public EventBase
 	{
 	public:

--- a/include/events/group_recall_event.hpp
+++ b/include/events/group_recall_event.hpp
@@ -9,7 +9,9 @@
 
 namespace Cyan
 {
-	// 群成员消息撤回事件
+	/**
+	 * \brief 群成员消息撤回事件
+	 */
 	class GroupRecallEvent : public EventBase
 	{
 	public:

--- a/include/events/join_request_event.hpp
+++ b/include/events/join_request_event.hpp
@@ -4,15 +4,14 @@
 
 #include <nlohmann/json.hpp>
 #include "defs/qq_types.hpp"
-#include "defs/serializable.hpp"
-#include "defs/message_chain.hpp"
-#include "defs/friend.hpp"
 #include "exported.h"
 #include "event_interface.hpp"
 
 namespace Cyan
 {
-	// 新成员入群请求
+	/**
+	 * \brief 新成员入群请求
+	 */
 	class EXPORTED MemberJoinRequestEvent : public EventBase
 	{
 	public:

--- a/include/events/member_join_event.hpp
+++ b/include/events/member_join_event.hpp
@@ -3,15 +3,15 @@
 #define mirai_cpp_events_member_join_event_hpp_H_
 
 #include <nlohmann/json.hpp>
-#include "defs/qq_types.hpp"
-#include "defs/serializable.hpp"
-#include "defs/message_chain.hpp"
 #include "defs/group_member.hpp"
 #include "event_interface.hpp"
 
 namespace Cyan
 {
-	// 新成员入群事件
+
+	/**
+	 * \brief 新成员入群事件
+	 */
 	class MemberJoinEvent : public EventBase
 	{
 	public:

--- a/include/events/member_leave_kick.hpp
+++ b/include/events/member_leave_kick.hpp
@@ -8,7 +8,9 @@
 
 namespace Cyan
 {
-	// 群成员被踢出群事件
+	/**
+	 * \brief 群成员被踢出群事件
+	 */
 	class MemberLeaveEventKick : public EventBase
 	{
 	public:

--- a/include/events/member_leave_quit.hpp
+++ b/include/events/member_leave_quit.hpp
@@ -3,14 +3,14 @@
 #define mirai_cpp_events_member_leave_quit_event_hpp_H_
 
 #include <nlohmann/json.hpp>
-#include "defs/qq_types.hpp"
-#include "defs/serializable.hpp"
 #include "defs/group_member.hpp"
 #include "event_interface.hpp"
 
 namespace Cyan
 {
-	// 群成员主动离群事件
+	/**
+	 * \brief 群成员主动离群事件
+	 */
 	class MemberLeaveEventQuit : public EventBase
 	{
 	public:

--- a/include/events/member_mute_event.hpp
+++ b/include/events/member_mute_event.hpp
@@ -8,7 +8,9 @@
 
 namespace Cyan
 {
-	// 群成员被禁言事件
+	/**
+	 * \brief 群成员被禁言事件
+	 */
 	class MemberMuteEvent : public EventBase
 	{
 	public:

--- a/include/events/member_unmute_event.hpp
+++ b/include/events/member_unmute_event.hpp
@@ -8,7 +8,9 @@
 
 namespace Cyan
 {
-	// 群成员被取消禁言事件
+	/**
+	 * \brief 群成员被取消禁言事件
+	 */
 	class MemberUnmuteEvent : public EventBase
 	{
 	public:

--- a/include/events/message_event.hpp
+++ b/include/events/message_event.hpp
@@ -20,7 +20,9 @@ namespace Cyan
 		TempMessage			// 临时消息
 	};
 
-	// 通用消息事件 (可转换为 FriendMessage GroupMessage TempMessage)
+	/**
+	 * \brief 通用消息事件 (可转换为 FriendMessage、GroupMessage、TempMessage)
+	 */
 	class EXPORTED Message : public EventBase
 	{
 	public:

--- a/include/events/new_friend_event.hpp
+++ b/include/events/new_friend_event.hpp
@@ -4,15 +4,14 @@
 
 #include <nlohmann/json.hpp>
 #include "defs/qq_types.hpp"
-#include "defs/serializable.hpp"
-#include "defs/message_chain.hpp"
-#include "defs/friend.hpp"
 #include "exported.h"
 #include "event_interface.hpp"
 
 namespace Cyan
 {
-	// 新好友请求事件
+	/**
+	 * \brief 新好友请求事件
+	 */
 	class EXPORTED NewFriendRequestEvent : public EventBase
 	{
 	public:

--- a/include/events/temp_message.hpp
+++ b/include/events/temp_message.hpp
@@ -4,7 +4,6 @@
 
 #include <nlohmann/json.hpp>
 #include "defs/qq_types.hpp"
-#include "defs/serializable.hpp"
 #include "defs/message_chain.hpp"
 #include "defs/group_member.hpp"
 #include "exported.h"
@@ -12,7 +11,9 @@
 
 namespace Cyan
 {
-	// 由群组发来的临时消息
+	/**
+	 * \brief 由群组发来的临时消息
+	 */
 	class EXPORTED TempMessage : public EventBase
 	{
 	public:

--- a/include/mirai.h
+++ b/include/mirai.h
@@ -2,6 +2,8 @@
 #ifndef mirai_cpp__mirai_h_H_
 #define mirai_cpp__mirai_h_H_
 
+#include "defs/defs.hpp"
+#include "events/events.hpp"
 #include "mirai_bot.hpp"
 
 #endif // !mirai_cpp__mirai_h_H_

--- a/include/mirai_bot.hpp
+++ b/include/mirai_bot.hpp
@@ -1,6 +1,7 @@
 ﻿#pragma once
 #ifndef mirai_cpp__mirai_bot_hpp_H_
 #define mirai_cpp__mirai_bot_hpp_H_
+// std libraries
 #include <string>
 #include <vector>
 #include <thread>
@@ -12,9 +13,17 @@
 #include "nlohmann/json.hpp"
 #include "httplib.h"
 // mirai header files
-#include "defs/defs.hpp"
-#include "events/events.hpp"
 #include "exported.h"
+#include "defs/qq_types.hpp"
+#include "defs/message_chain.hpp"
+#include "defs/friend.hpp"
+#include "defs/group.hpp"
+#include "defs/group_member.hpp"
+#include "defs/group_member_info.hpp"
+#include "defs/group_config.hpp"
+#include "events/event_processer.hpp"
+#include "events/friend_message.hpp"
+#include "events/group_message.hpp"
 
 using std::string;
 using std::vector;


### PR DESCRIPTION
简单快速的用法，引用 mirai.h 自动引入所有定义和事件：

```C++
#include <mirai.h>
using namespace Cyan;
```

灵活的使用方法，可以一定程度上加快编译速度（理论上）：

```C++
#include <mirai_bot.hpp>
// 需要什么事件就引入什么事件:
#include <events/bot_mute_event.hpp>
#include <events/bot_unmute_event.hpp>
#include <events/bot_leave_kick.hpp>
using namespace Cyan;
```