### PR TITLE
重构，将Serializable更名为ISerializable；

### DIFF
--- a/include/defs/friend.hpp
+++ b/include/defs/friend.hpp
@@ -10,7 +10,7 @@ namespace Cyan
 {
 
 	// 好友数据格式
-	class Friend_t : public Serializable
+	class Friend_t : public ISerializable
 	{
 	public:
 		QQ_t QQ;

--- a/include/defs/group.hpp
+++ b/include/defs/group.hpp
@@ -10,7 +10,7 @@ namespace Cyan
 {
 
 	// 群组数据格式
-	class Group_t : public Serializable
+	class Group_t : public ISerializable
 	{
 	public:
 		GID_t GID;

--- a/include/defs/group_config.hpp
+++ b/include/defs/group_config.hpp
@@ -8,7 +8,7 @@
 namespace Cyan
 {
 	// »∫…Ë÷√
-	class GroupConfig : public Serializable
+	class GroupConfig : public ISerializable
 	{
 	public:
 		string Name;

--- a/include/defs/group_member.hpp
+++ b/include/defs/group_member.hpp
@@ -11,7 +11,7 @@ namespace Cyan
 {
 
 	// 群组成员格式
-	class GroupMember_t : public Serializable
+	class GroupMember_t : public ISerializable
 	{
 	public:
 		QQ_t QQ;

--- a/include/defs/group_member_info.hpp
+++ b/include/defs/group_member_info.hpp
@@ -11,7 +11,7 @@ namespace Cyan
 {
 
 	// 群组成员信息
-	class GroupMemberInfo : public Serializable
+	class GroupMemberInfo : public ISerializable
 	{
 	public:
 		string Name;

--- a/include/defs/message_chain.hpp
+++ b/include/defs/message_chain.hpp
@@ -23,7 +23,7 @@ namespace Cyan
 		FangDaZhao
 	};
 
-	class MessageChain : public Serializable
+	class MessageChain : public ISerializable
 	{
 	public:
 		friend MessageChain& operator+(const string& str, MessageChain& mc);

--- a/include/defs/message_interface.hpp
+++ b/include/defs/message_interface.hpp
@@ -1,0 +1,19 @@
+#pragma once
+#ifndef mirai_cpp_defs_message_interface_hpp_H_
+#define mirai_cpp_defs_message_interface_hpp_H_
+
+#include <nlohmann/json.hpp>
+#include "serializable.hpp"
+
+namespace Cyan
+{
+
+	class IMessage : public ISerializable
+	{
+
+
+	};
+
+}
+#endif
+

--- a/include/defs/serializable.hpp
+++ b/include/defs/serializable.hpp
@@ -12,8 +12,8 @@ namespace Cyan
 	{
 	public:
 		Serializable() {}
-		virtual bool Set(const json& json) { return false; }
-		virtual json ToJson() const { return json::object(); }
+		virtual bool Set(const json& json) = 0;
+		virtual json ToJson() const = 0;
 		virtual string ToString() const
 		{
 			return ToJson().dump();

--- a/include/defs/serializable.hpp
+++ b/include/defs/serializable.hpp
@@ -8,17 +8,17 @@ using nlohmann::json;
 
 namespace Cyan
 {
-	class Serializable
+	class ISerializable
 	{
 	public:
-		Serializable() {}
+		ISerializable() {}
 		virtual bool Set(const json& json) = 0;
 		virtual json ToJson() const = 0;
 		virtual string ToString() const
 		{
 			return ToJson().dump();
 		}
-		virtual ~Serializable() {}
+		virtual ~ISerializable() {}
 	};
 
 

--- a/include/events/event_interface.hpp
+++ b/include/events/event_interface.hpp
@@ -28,6 +28,16 @@ namespace Cyan
 			return *this;
 		}
 		
+		virtual bool Set(const json& json) override
+		{
+			return true;
+		}
+
+		virtual json ToJson() const override
+		{
+			return json::object();
+		}
+
 		virtual ~EventBase() = default;
 		
 		static MiraiEvent GetMiraiEvent()

--- a/include/events/event_interface.hpp
+++ b/include/events/event_interface.hpp
@@ -6,7 +6,7 @@
 #include "defs/qq_types.hpp"
 namespace Cyan
 {
-	class EventBase : public Serializable
+	class EventBase : public ISerializable
 	{
 	public:
 		EventBase() : bot_(nullptr) {}


### PR DESCRIPTION
重构，将Serializable更名为ISerializable；
1. 将Serializable设计为抽象类 （早就该这么做了）
2. 因为Serializable被作为接口使用，更名为ISerializable （不要问抽象类为啥用接口的命名规范，Abstract的前缀可比I长的多）