### PR TITLE
修复: 未对GetGroupMemberInfo查找失败的情况进行处理

### DIFF
--- a/src/mirai_bot.cpp
+++ b/src/mirai_bot.cpp
@@ -359,6 +359,10 @@ namespace Cyan
 		if (res->status != 200)
 			throw std::runtime_error("[mirai-api-http error]: " + res->body);
 		json re_json = json::parse(res->body);
+		if (re_json.find("code") != re_json.end())
+		{
+			throw std::runtime_error(re_json["msg"]);
+		}
 		GroupMemberInfo result;
 		result.Set(re_json);
 		return result;


### PR DESCRIPTION
### 问题
未对GetGroupMemberInfo查找失败的情况进行处理（对象不存在导致查找失败）
### 修复方法
如果存在code字段，则说明失败。（成功时不存在code字段，直接是GroupMemberInfo的数据）
### 影响
未来可能移除该修改，因为这种情况应当返回非200状态码。