### PR TITLE
修复: GCC下字符串字面量和MessageChain相加的编译错误

### DIFF
--- a/include/mirai/defs/message_chain.hpp
+++ b/include/mirai/defs/message_chain.hpp
@@ -35,7 +35,7 @@ namespace Cyan
 
 		friend MessageChain& operator+(const string& str, MessageChain& mc);
 		template<int N>
-		friend MessageChain& operator+(const char(&str)[N], MessageChain& mc);
+		friend MessageChain& operator+(const char(&str)[N], MessageChain&& mc);
 		MessageChain();
 		MessageChain(const MessageChain& mc);
 		MessageChain(MessageChain&& mc) noexcept;
@@ -219,7 +219,7 @@ namespace Cyan
 	};
 
 	template<int N>
-	inline MessageChain& operator+(const char(&str)[N], MessageChain& mc)
+	inline MessageChain& operator+(const char(&str)[N], MessageChain&& mc)
 	{
 		mc.messages_.insert(mc.messages_.begin(), std::make_shared<PlainMessage>(str));
 		return mc;


### PR DESCRIPTION
修复: GCC下字符串字面量和MessageChain相加的编译错误