### PR TITLE
提升 MessageChain 的易用性.

### DIFF
--- a/include/mirai/defs/message_chain.hpp
+++ b/include/mirai/defs/message_chain.hpp
@@ -117,6 +117,11 @@ namespace Cyan
 			return messages_.size();
 		}
 
+		bool Empty() const
+		{
+			return Count() == 0;
+		}
+
 		void Clear()
 		{
 			messages_.clear();

--- a/src/message_chain.cpp
+++ b/src/message_chain.cpp
@@ -66,11 +66,6 @@ namespace Cyan
 		return this->Plain(val);
 	}
 
-	MessageChain& MessageChain::operator+=(const string& val)
-	{
-		return this->Plain(val);
-	}
-
 	bool MessageChain::operator==(const MessageChain& mc) const
 	{
 		if (this->messages_.size() != mc.messages_.size()) return false;


### PR DESCRIPTION
1. 增加 Empty 方法，检查 MessageChain 是否为空
2. 增加 对 IMessage 的运算符重载 (但是一般不推荐使用，因为会导致无意义的拷贝)