### PR TITLE
Remove 'Announcement' field from group_config

### DIFF
--- a/include/mirai/defs/group_config.hpp
+++ b/include/mirai/defs/group_config.hpp
@@ -21,7 +21,7 @@ namespace Cyan
 		/**
 		 * @brief 群公告
 		*/
-		string Announcement;
+//		string Announcement;
 
 		/**
 		 * @brief 是否允许坦白说
@@ -46,7 +46,7 @@ namespace Cyan
 		virtual bool Set(const json& j) override
 		{
 			Name = j["name"].get<string>();
-			Announcement = j["announcement"].get<string>();
+//			Announcement = j["announcement"].get<string>();
 			ConfessTalk = j["confessTalk"].get<bool>();
 			AllowMemberInvite = j["allowMemberInvite"].get<bool>();
 			AutoApprove = j["autoApprove"].get<bool>();
@@ -58,7 +58,7 @@ namespace Cyan
 		{
 			json j = json::object();
 			j["name"] = Name;
-			j["announcement"] = Announcement;
+//			j["announcement"] = Announcement;
 			j["confessTalk"] = ConfessTalk;
 			j["allowMemberInvite"] = AllowMemberInvite;
 			j["autoApprove"] = AutoApprove;

--- a/include/mirai/mirai_bot.hpp
+++ b/include/mirai/mirai_bot.hpp
@@ -229,7 +229,7 @@ namespace Cyan
 		 * @param withDownloadInfo 获取下载信息(需要较长时间)
 		 * @return GroupFile
 		*/
-		GroupFile GetGroupFilById(const GID_t& gid, const string& groupFileId, bool withDownloadInfo = false);
+		GroupFile GetGroupFileById(const GID_t& gid, const string& groupFileId, bool withDownloadInfo = false);
 
 		/**
 		 * @brief 创建群文件夹

--- a/src/mirai_bot.cpp
+++ b/src/mirai_bot.cpp
@@ -692,7 +692,7 @@ namespace Cyan
 		return result;
 	}
 
-	GroupFile MiraiBot::GetGroupFilById(const GID_t& gid, const string& groupFileId, bool withDownloadInfo)
+	GroupFile MiraiBot::GetGroupFileById(const GID_t& gid, const string& groupFileId, bool withDownloadInfo)
 	{
 		stringstream api_url;
 		api_url


### PR DESCRIPTION
[https://github.com/project-mirai/mirai-api-http/releases/tag/v2.3.0](https://github.com/project-mirai/mirai-api-http/releases/tag/v2.3.0)

mirai-api-http 自v2.3.0起移除了群公告参数，目前使用getGroupConfig和setGroupConfig会导致程序崩溃。