### PR TITLE
Correctly implement the MessageChain::operator== function.

### DIFF
--- a/src/MessageChain.cpp
+++ b/src/MessageChain.cpp
@@ -85,7 +85,7 @@ namespace Cyan
 		if (this->messages_.size() != mc.messages_.size()) return false;
 		for (size_t i = 0; i < messages_.size(); ++i)
 		{
-			if (messages_[i] != mc.messages_[i]) return false;
+			if (*messages_[i] != *mc.messages_[i]) return false;
 		}
 		return true;
 	}


### PR DESCRIPTION
Closes #131 