### PR TITLE
Fix VoiceMessage

### DIFF
--- a/include/mirai/messages/VoiceMessage.hpp
+++ b/include/mirai/messages/VoiceMessage.hpp
@@ -97,10 +97,6 @@ namespace Cyan
 			json result = 
 			{
 				{ "type", type_ },
-				{ "voiceId", voiceId_.empty() ? nullptr : voiceId_ },
-				{ "url", url_.empty() ? nullptr : url_ },
-				{ "path", path_.empty() ? nullptr : path_ },
-				{ "base64", base64_.empty() ? nullptr : base64_ },
 				{ "length", length_ }
 			};
 
@@ -153,7 +149,7 @@ namespace Cyan
 	private:
 		const string type_ = "Voice";
 	protected:
-		size_t length_;
+		size_t length_{};
 		string voiceId_;
 		string url_;
 		string path_;

--- a/include/mirai/messages/VoiceMessage.hpp
+++ b/include/mirai/messages/VoiceMessage.hpp
@@ -19,7 +19,7 @@ namespace Cyan
 			length_(0) {}
 		VoiceMessage(const VoiceMessage& m) : 
 			voiceId_(m.voiceId_), 
-			url_(m.voiceId_), 
+			url_(m.url_), 
 			path_(m.path_), 
 			base64_(m.base64_), 
 			length_(m.length_) {}

--- a/src/MessageChain.cpp
+++ b/src/MessageChain.cpp
@@ -26,6 +26,7 @@ namespace Cyan
 			reflection.Register<DiceMessage>("Dice");
 			reflection.Register<ForwardMessage>("Forward");
 			reflection.Register<MusicShare>("MusicShare");
+			reflection.Register<VoiceMessage>("Voice");
 		}
 		return reflection;
 	}


### PR DESCRIPTION
- 修复三元运算符返回类型不一致问题
- 为_length增加默认构造
- typo in the copy constructor of VoiceMessage
- Add VoiceMessage to reflection

其中第三点应该是 #154 的问题来源
